### PR TITLE
Make the grammar PCRE compatible

### DIFF
--- a/grammars/harbour.cson
+++ b/grammars/harbour.cson
@@ -53,7 +53,7 @@
   }
   'escaped_character': {
     'name': 'constant.character.escape.harbour'
-    'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+    'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
   }
   'sigils': {
     'comment': 'Sigil'

--- a/grammars/harbour.cson
+++ b/grammars/harbour.cson
@@ -53,7 +53,7 @@
   }
   'escaped_character': {
     'name': 'constant.character.escape.harbour'
-    'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+    'match': '\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
   }
   'sigils': {
     'comment': 'Sigil'


### PR DESCRIPTION
This pull request changes 1 regular expressions in an attempt to make the grammar PCRE-compatible. While Atom uses an Oniguruma engine, github.com (which rely on this grammar for Harbour highlighting) uses a PCRE-based engine. The two engines interpret `\h` differently, and only Oniguruma engines support implicit count modifiers (`{,n}`).